### PR TITLE
refactor(CrosswordGrid): replace ref-based implementation with CSS-only approach

### DIFF
--- a/src/Crossword/components/CrosswordCore/CrosswordGrid.tsx
+++ b/src/Crossword/components/CrosswordCore/CrosswordGrid.tsx
@@ -1,46 +1,340 @@
-import React, {
-  useContext,
-  useMemo,
-  useRef,
-} from 'react';
-import PropTypes, { InferProps } from 'prop-types';
+//? Old implementation using  refs, I refactored into css only
+// import React, { useContext, useEffect, useMemo, useRef, useState } from "react";
+// import PropTypes, { InferProps } from "prop-types";
 
-import styled, { ThemeContext } from 'styled-components';
+// import styled, { ThemeContext } from "styled-components";
 
-import Cell from './Cell'; // Assuming Cell component is in the same directory
-import { getCellKey } from '../../../lib/utils'; // Import getCellKey utility
+// import Cell from "./Cell"; // Assuming Cell component is in the same directory
+// import { getCellKey } from "../../../lib/utils"; // Import getCellKey utility
 
-import { CrosswordContext, CrosswordSizeContext } from './context';
-import { InputRefCallback } from '../../types'; // Removed FocusHandler import
+// import { CrosswordContext, CrosswordSizeContext } from "./context";
+// import { InputRefCallback } from "../../types"; // Removed FocusHandler import
 
-// GridWrapper styling remains unchanged
-const GridWrapper = styled.div.attrs((/* props */) => ({
-  className: 'crossword grid',
-}))`
-  /* position: relative; */
-  /* min-width: 20rem; */
-  /* max-width: 60rem; Should the size matter? */
-  width: auto;
-  flex: 2 1 50%;
+// // GridWrapper styling remains unchanged
+// // const GridWrapper = styled.div.attrs((/* props */) => ({
+// //   className: "crossword grid",
+// // }))`
+// //   display: flex; /* turn into a flex-item */
+// //   flex: 1 1 auto; /* grow and shrink to fill parent */
+// //   min-height: 0; /* allow shrinking below content height */
+// //   width: 100%;
+// // `;
+
+// export const SvgWrapper = styled.div`
+//   position: relative;
+//   display: flex;
+//   justify-content: center;
+//   align-items: center;
+//   flex: 1 1 auto;
+//   min-height: 0;
+//   overflow: hidden;
+// `;
+
+// // Update PropTypes to include onInputRefChange
+// const CrosswordGridPropTypes = {
+//   // theme prop removed since it's now consumed from context
+//   onInputRefChange: PropTypes.func,
+// };
+
+// // Define an explicit interface that extends the inferred props
+// interface ICrosswordGridProps
+//   extends InferProps<typeof CrosswordGridPropTypes> {
+//   onInputRefChange?: InputRefCallback;
+// }
+
+// /**
+//  * The rendering component for the crossword grid itself.
+//  */
+// export default function CrosswordGrid({
+//   onInputRefChange,
+// }: ICrosswordGridProps) {
+//   // Destructure necessary values from CrosswordContext
+//   // Renamed context props locally for clarity (focusedRow, focusedCol)
+//   const {
+//     rows,
+//     cols,
+//     gridData,
+//     cellCompletionStatus,
+//     handleInputKeyDown,
+//     handleInputChange,
+//     handleCellClick, // The context function itself
+//     handleInputClick,
+//     focused, // The internal focus state of the hidden input
+//     selectedPosition: { row: focusedRow, col: focusedCol }, // The selected cell coordinates
+//     selectedDirection: currentDirection, // The selected direction
+//     selectedNumber: currentNumber, // The selected clue number
+//   } = useContext(CrosswordContext);
+
+//   // Keep inputRef for the callback pattern
+//   const inputRef = useRef<HTMLInputElement>(null);
+
+//   const wrapperRef = useRef<HTMLDivElement>(null);
+//   const [wrapperSize, setWrapperSize] = useState({ width: 0, height: 0 });
+
+//   useEffect(() => {
+//     if (!wrapperRef.current) return;
+//     const ro = new ResizeObserver((entries) => {
+//       for (let entry of entries) {
+//         const { width, height } = entry.contentRect;
+//         setWrapperSize({ width, height });
+//       }
+//     });
+//     ro.observe(wrapperRef.current);
+//     return () => ro.disconnect();
+//   }, []);
+
+//   const cellSize = useMemo(() => {
+//     if (cols === 0 || rows === 0) return 0;
+//     const size = Math.min(wrapperSize.width / cols, wrapperSize.height / rows);
+//     console.log("size", size);
+//     return size;
+//   }, [wrapperSize, cols, rows]);
+
+//   // Get the theme directly from context
+//   const finalTheme = useContext(ThemeContext);
+
+//   // Calculate sizing based on cell size (remains unchanged)
+//   // const cellSize = 10;
+//   // 3) ✨ Derive all the constants off of that
+//   const cellPadding = cellSize * 0.0125; // same ratio as .125 / 10
+//   const cellInner = cellSize - cellPadding * 2;
+//   const cellHalf = cellSize / 2;
+//   const fontSize = cellInner * 0.7;
+
+//   const sizeContext = useMemo(
+//     () => ({ cellSize, cellPadding, cellInner, cellHalf, fontSize }),
+//     [cellSize, cellPadding, cellInner, cellHalf, fontSize]
+//   );
+
+//   // 4) ✨ SVG dimensions from dynamic cellSize
+//   const svgWidth = cols * cellSize;
+//   const svgHeight = rows * cellSize;
+
+//   // Hidden input styling just scales with the same percentages
+//   const cellWidthPct = 100 / cols;
+//   const cellHeightPct = 100 / rows;
+//   // useMemo(() => {
+//   //   console.log("cellWidthPct", svgWidth);
+//   // }, [svgWidth]);
+//   useMemo(() => {
+//     console.log("cellHeightPct", cellHeightPct);
+//   }, [cellHeightPct]);
+//   useMemo(() => {
+//     console.log("svgHeight", svgHeight);
+//   }, [svgHeight]);
+
+//   const inputStyle = useMemo(
+//     () =>
+//       ({
+//         position: "absolute",
+//         top: `calc(${focusedRow * cellHeightPct}% + 2px)`,
+//         left: `calc(${focusedCol * cellWidthPct}% + 2px)`,
+//         width: `calc(${cellWidthPct}% - 4px)`,
+//         height: `calc(${cellHeightPct}% - 4px)`,
+//         fontSize: `${fontSize * 6}px`,
+//         textAlign: "center",
+//         backgroundColor: "transparent",
+//         caretColor: "transparent",
+//         margin: 0,
+//         padding: 0,
+//         border: 0,
+//         outline: "none",
+//         cursor: "default",
+//       } as const),
+//     [cellWidthPct, cellHeightPct, focusedRow, focusedCol, fontSize]
+//   );
+
+//   //? I commented out the old implementation
+//   // const sizeContext = useMemo(
+//   //   () => ({
+//   //     cellSize,
+//   //     cellPadding,
+//   //     cellInner,
+//   //     cellHalf,
+//   //     fontSize,
+//   //   }),
+//   //   [cellSize, cellPadding, cellInner, cellHalf, fontSize] // Dependencies are constants, but keep for clarity
+//   // );
+
+//   // const height = useMemo(() => rows * cellSize, [rows, cellSize]);
+//   // const width = useMemo(() => cols * cellSize, [cols, cellSize]);
+//   // const cellWidthHtmlPct = useMemo(() => 100 / cols, [cols]);
+//   // const cellHeightHtmlPct = useMemo(() => 100 / rows, [rows]);
+
+//   // // Style for the hidden input (remains unchanged)
+//   // const inputStyle = useMemo(
+//   //   () =>
+//   //     ({
+//   //       position: "absolute",
+//   //       // Adjustments to align input (unchanged from original)
+//   //       top: `calc(${focusedRow * cellHeightHtmlPct * 0.995}% + 2px)`,
+//   //       left: `calc(${focusedCol * cellWidthHtmlPct}% + 2px)`,
+//   //       width: `calc(${cellWidthHtmlPct}% - 4px)`,
+//   //       height: `calc(${cellHeightHtmlPct}% - 4px)`,
+//   //       fontSize: `${fontSize * 6}px`, // Font size might need adjustment
+//   //       textAlign: "center",
+//   //       textAnchor: "middle",
+//   //       backgroundColor: "transparent",
+//   //       caretColor: "transparent", // Hide caret
+//   //       margin: 0,
+//   //       padding: 0,
+//   //       border: 0,
+//   //       outline: "none",
+//   //       cursor: "default",
+//   //     } as const), // Using 'as const' for stricter type checking on style object
+//   //   [cellWidthHtmlPct, cellHeightHtmlPct, focusedRow, focusedCol, fontSize]
+//   // );
+
+//   return (
+//     <CrosswordSizeContext.Provider value={sizeContext}>
+//       {/* <GridWrapper> */}
+//       {/* Outer div for positioning the input correctly */}
+//       <div
+//         style={{
+//           position: "relative",
+//           flex: 1 /* fill the GridWrapper’s height */,
+//           minHeight: 0 /* again, allow it to shrink */,
+//           overflow: "hidden" /* clip anything outside */,
+//           display: "flex",
+//           justifyContent: "center",
+//           alignItems: "center",
+//           flexGrow: 1,
+//           flexShrink: 1,
+//           flexBasis: "auto",
+//           height: "100%",
+//         }}
+//         id={"svg-size-wrapper"}
+//         ref={wrapperRef}
+//       >
+//         <svg
+//           viewBox={`0 0 ${svgWidth} ${svgHeight}`}
+//           preserveAspectRatio="xMidYMid meet"
+//           style={{
+//             display: "block",
+//             width: "100%",
+//             height: "100%",
+//           }}
+//         >
+//           {/* Background rectangle */}
+//           <rect
+//             x={0}
+//             y={0}
+//             width={svgWidth}
+//             height={svgHeight}
+//             fill={finalTheme?.gridBackground ?? "transparent"}
+//           />
+//           {/* Render cells */}
+//           {gridData.flatMap((rowData, row) =>
+//             rowData.map((cellData, col) => {
+//               // Skip rendering if the cell is not used
+//               if (!cellData.used) {
+//                 return undefined;
+//               }
+
+//               // --- CORRECTED FOCUS/HIGHLIGHT CALCULATIONS ---
+//               // Determine if this cell is the currently focused cell based on context coordinates
+//               const isFocused = row === focusedRow && col === focusedCol;
+
+//               // Determine if this cell is part of the highlighted clue based on context direction/number
+//               const isHighlighted =
+//                 !!currentNumber && cellData[currentDirection] === currentNumber;
+
+//               // Get the cell completion status from the map
+//               const cellKey = getCellKey(row, col);
+//               const completionStatus = cellCompletionStatus?.get(cellKey);
+//               // --- END CORRECTIONS ---
+
+//               // --- TEMPORARY LOGGING (Uncomment to use) ---
+//               /*
+//                 console.log(
+//                   `[Grid Rendering Cell ${row},${col}] ContextPos: (${focusedRow},${focusedCol}), ContextDir: ${currentDirection}, ContextNum: ${currentNumber} => Calculated: focus=${isFocused}, highlight=${isHighlighted}`
+//                 );
+//                 */
+//               // --- END LOGGING ---
+
+//               // Render the Cell component
+//               return (
+//                 <Cell
+//                   // Using standardized utility function for cell keys
+//                   key={getCellKey(row, col)}
+//                   cellData={cellData}
+//                   focus={isFocused} // Pass calculated focus state
+//                   highlight={isHighlighted} // Pass calculated highlight state
+//                   completionStatus={completionStatus} // Pass completion status
+//                   // --- CORRECTED onClick ---
+//                   // Wrap context handler to pass correct cellData argument
+//                   onClick={() => handleCellClick(cellData)}
+//                 />
+//               );
+//             })
+//           )}
+//         </svg>
+//         {/* Hidden input field for capturing keyboard events */}
+//         <input
+//           ref={(node: HTMLInputElement | null) => {
+//             // Keep the inputRef for local use
+//             inputRef.current = node;
+//             // Call the callback passed from App.tsx if provided
+//             onInputRefChange?.(node);
+//           }}
+//           aria-label="crossword-input"
+//           type="text"
+//           onClick={handleInputClick}
+//           onKeyDown={handleInputKeyDown}
+//           onChange={handleInputChange}
+//           value=""
+//           autoComplete="off"
+//           spellCheck="false"
+//           autoCorrect="off"
+//           style={inputStyle}
+//         />
+//       </div>
+//       {/* </GridWrapper> */}
+//     </CrosswordSizeContext.Provider>
+//   );
+// }
+
+// // Assign propTypes (remains unchanged)
+// CrosswordGrid.propTypes = CrosswordGridPropTypes;
+
+// // Export the type for other components
+// export type CrosswordGridProps = ICrosswordGridProps;
+
+import React, { useContext, useRef } from "react";
+import PropTypes, { InferProps } from "prop-types";
+import styled, { ThemeContext } from "styled-components";
+import Cell from "./Cell";
+import { getCellKey } from "../../../lib/utils";
+import { CrosswordContext } from "./context";
+import { InputRefCallback } from "../../types";
+
+const SvgWrapper = styled.div`
+  position: relative;
+  display: flex;
+  flex: 1 1 auto;
+  min-height: 0; /* important for flex‐shrink */
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
 `;
 
-// Update PropTypes to include onInputRefChange
+const StyledSvg = styled.svg`
+  width: 100%;
+  height: 100%;
+`;
+
 const CrosswordGridPropTypes = {
-  // theme prop removed since it's now consumed from context
   onInputRefChange: PropTypes.func,
 };
 
-// Define an explicit interface that extends the inferred props
-interface ICrosswordGridProps extends InferProps<typeof CrosswordGridPropTypes> {
+interface ICrosswordGridProps
+  extends InferProps<typeof CrosswordGridPropTypes> {
   onInputRefChange?: InputRefCallback;
 }
 
-/**
- * The rendering component for the crossword grid itself.
- */
-export default function CrosswordGrid({ onInputRefChange }: ICrosswordGridProps) {
-  // Destructure necessary values from CrosswordContext
-  // Renamed context props locally for clarity (focusedRow, focusedCol)
+export default function CrosswordGrid({
+  onInputRefChange,
+}: ICrosswordGridProps) {
   const {
     rows,
     cols,
@@ -48,154 +342,134 @@ export default function CrosswordGrid({ onInputRefChange }: ICrosswordGridProps)
     cellCompletionStatus,
     handleInputKeyDown,
     handleInputChange,
-    handleCellClick, // The context function itself
+    handleCellClick,
     handleInputClick,
-    focused, // The internal focus state of the hidden input
-    selectedPosition: { row: focusedRow, col: focusedCol }, // The selected cell coordinates
-    selectedDirection: currentDirection, // The selected direction
-    selectedNumber: currentNumber, // The selected clue number
+    selectedPosition: { row: focusedRow, col: focusedCol },
+    selectedDirection,
+    selectedNumber,
   } = useContext(CrosswordContext);
 
-  // Keep inputRef for the callback pattern
+  const finalTheme = useContext(ThemeContext);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  // Get the theme directly from context
-  const finalTheme = useContext(ThemeContext);
+  // Percent sizes for the input overlay
+  const cellWidthPct = 100 / cols;
+  const cellHeightPct = 100 / rows;
 
-  // Calculate sizing based on cell size (remains unchanged)
-  const cellSize = 10;
-  const cellPadding = 0.125;
-  const cellInner = cellSize - cellPadding * 2;
-  const cellHalf = cellSize / 2;
-  const fontSize = cellInner * 0.7;
-
-  const sizeContext = useMemo(
-    () => ({
-      cellSize,
-      cellPadding,
-      cellInner,
-      cellHalf,
-      fontSize,
-    }),
-    [cellSize, cellPadding, cellInner, cellHalf, fontSize] // Dependencies are constants, but keep for clarity
-  );
-
-  const height = useMemo(() => rows * cellSize, [rows]);
-  const width = useMemo(() => cols * cellSize, [cols]);
-  const cellWidthHtmlPct = useMemo(() => 100 / cols, [cols]);
-  const cellHeightHtmlPct = useMemo(() => 100 / rows, [rows]);
-
-  // Style for the hidden input (remains unchanged)
-  const inputStyle = useMemo(
-    () =>
-      ({
-        position: 'absolute',
-        // Adjustments to align input (unchanged from original)
-        top: `calc(${focusedRow * cellHeightHtmlPct * 0.995}% + 2px)`,
-        left: `calc(${focusedCol * cellWidthHtmlPct}% + 2px)`,
-        width: `calc(${cellWidthHtmlPct}% - 4px)`,
-        height: `calc(${cellHeightHtmlPct}% - 4px)`,
-        fontSize: `${fontSize * 6}px`, // Font size might need adjustment
-        textAlign: 'center',
-        textAnchor: 'middle',
-        backgroundColor: 'transparent',
-        caretColor: 'transparent', // Hide caret
-        margin: 0,
-        padding: 0,
-        border: 0,
-        outline: 'none',
-        cursor: 'default',
-      } as const), // Using 'as const' for stricter type checking on style object
-    [cellWidthHtmlPct, cellHeightHtmlPct, focusedRow, focusedCol, fontSize]
-  );
+  // SVG viewBox maps directly to #columns × #rows
+  const viewBox = `0 0 ${cols} ${rows}`;
 
   return (
-    <CrosswordSizeContext.Provider value={sizeContext}>
-      <GridWrapper>
-        {/* Outer div for positioning the input correctly */}
-        <div style={{ margin: 0, padding: 0, position: 'relative' }}>
-          <svg viewBox={`0 0 ${width} ${height}`}>
-            {/* Background rectangle */}
-            <rect
-              x={0}
-              y={0}
-              width={width}
-              height={height}
-              fill={finalTheme?.gridBackground ?? 'transparent'}
-            />
-            {/* Render cells */}
-            {gridData.flatMap((rowData, row) =>
-              rowData.map((cellData, col) => {
-                // Skip rendering if the cell is not used
-                if (!cellData.used) {
-                  return undefined;
-                }
+    <SvgWrapper>
+      <StyledSvg viewBox={viewBox} preserveAspectRatio="xMidYMid meet">
+        {/* full‑grid background */}
+        <rect
+          x={0}
+          y={0}
+          width={cols}
+          height={rows}
+          fill={finalTheme?.gridBackground ?? "transparent"}
+        />
 
-                // --- CORRECTED FOCUS/HIGHLIGHT CALCULATIONS ---
-                // Determine if this cell is the currently focused cell based on context coordinates
-                const isFocused = row === focusedRow && col === focusedCol;
+        {/* each cell is a 1×1 square at (col,row) */}
+        {gridData.flatMap((rowData, row) =>
+          rowData.map((cellData, col) => {
+            if (!cellData.used) return null;
 
-                // Determine if this cell is part of the highlighted clue based on context direction/number
-                const isHighlighted =
-                  !!currentNumber && cellData[currentDirection] === currentNumber;
-                
-                // Get the cell completion status from the map
-                const cellKey = getCellKey(row, col);
-                const completionStatus = cellCompletionStatus?.get(cellKey);
-                // --- END CORRECTIONS ---
+            const isFocused = row === focusedRow && col === focusedCol;
+            const isHighlighted =
+              !!selectedNumber &&
+              cellData[selectedDirection] === selectedNumber;
 
-                // --- TEMPORARY LOGGING (Uncomment to use) ---
-                /*
-                console.log(
-                  `[Grid Rendering Cell ${row},${col}] ContextPos: (${focusedRow},${focusedCol}), ContextDir: ${currentDirection}, ContextNum: ${currentNumber} => Calculated: focus=${isFocused}, highlight=${isHighlighted}`
-                );
-                */
-                // --- END LOGGING ---
+            const key = getCellKey(row, col);
+            const completion = cellCompletionStatus?.get(key);
 
-                // Render the Cell component
-                return (
-                  <Cell
-                    // Using standardized utility function for cell keys
-                    key={getCellKey(row, col)}
-                    cellData={cellData}
-                    focus={isFocused}      // Pass calculated focus state
-                    highlight={isHighlighted} // Pass calculated highlight state
-                    completionStatus={completionStatus} // Pass completion status
-                    // --- CORRECTED onClick ---
-                    // Wrap context handler to pass correct cellData argument
-                    onClick={() => handleCellClick(cellData)}
-                  />
-                );
-              })
-            )}
-          </svg>
-          {/* Hidden input field for capturing keyboard events */}
-          <input
-            ref={(node: HTMLInputElement | null) => {
-              // Keep the inputRef for local use
-              inputRef.current = node;
-              // Call the callback passed from App.tsx if provided
-              onInputRefChange?.(node);
-            }}
-            aria-label="crossword-input"
-            type="text"
-            onClick={handleInputClick}
-            onKeyDown={handleInputKeyDown}
-            onChange={handleInputChange}
-            value=""
-            autoComplete="off"
-            spellCheck="false"
-            autoCorrect="off"
-            style={inputStyle}
-          />
-        </div>
-      </GridWrapper>
-    </CrosswordSizeContext.Provider>
+            return (
+              <g key={key} transform={`translate(${col}, ${row})`}>
+                <rect
+                  x={0}
+                  y={0}
+                  width={1}
+                  height={1}
+                  fill={finalTheme?.cellBackground ?? "#fffaf0"}
+                  stroke={finalTheme?.cellBorder ?? "#dde1e4"}
+                  strokeWidth={0.02}
+                  className={
+                    isFocused
+                      ? "focused"
+                      : isHighlighted
+                      ? "highlighted"
+                      : undefined
+                  }
+                />
+
+                {/* clue number */}
+                {cellData.number && (
+                  <text
+                    x={0.05}
+                    y={0.05}
+                    fontSize={0.3}
+                    textAnchor="start"
+                    dominantBaseline="hanging"
+                    fill={finalTheme?.numberColor ?? "#7f8c8d"}
+                  >
+                    {cellData.number}
+                  </text>
+                )}
+
+                {/* letter guess */}
+                <text
+                  x={0.5}
+                  y={0.5}
+                  fontSize={0.7}
+                  textAnchor="middle"
+                  dominantBaseline="middle"
+                  className="guess-text"
+                  fill={finalTheme?.textColor ?? "#2c3e50"}
+                >
+                  {completion || ""}
+                </text>
+              </g>
+            );
+          })
+        )}
+      </StyledSvg>
+
+      {/* hidden input over the “active” cell, purely percent‑based */}
+      <input
+        ref={(node) => {
+          inputRef.current = node;
+          onInputRefChange?.(node);
+        }}
+        aria-label="crossword-input"
+        type="text"
+        onClick={handleInputClick}
+        onKeyDown={handleInputKeyDown}
+        onChange={handleInputChange}
+        value=""
+        autoComplete="off"
+        spellCheck="false"
+        autoCorrect="off"
+        style={{
+          position: "absolute",
+          top: `calc(${focusedRow * cellHeightPct}% + 2px)`,
+          left: `calc(${focusedCol * cellWidthPct}% + 2px)`,
+          width: `calc(${cellWidthPct}% - 4px)`,
+          height: `calc(${cellHeightPct}% - 4px)`,
+          fontSize: `calc((100% / ${rows}) * 0.7)`,
+          textAlign: "center",
+          backgroundColor: "transparent",
+          caretColor: "transparent",
+          margin: 0,
+          padding: 0,
+          border: 0,
+          outline: "none",
+          cursor: "default",
+        }}
+      />
+    </SvgWrapper>
   );
 }
 
-// Assign propTypes (remains unchanged)
 CrosswordGrid.propTypes = CrosswordGridPropTypes;
-
-// Export the type for other components
 export type CrosswordGridProps = ICrosswordGridProps;

--- a/src/Layout/components.ts
+++ b/src/Layout/components.ts
@@ -1,17 +1,22 @@
-import styled from 'styled-components';
+import styled from "styled-components";
 
 // Main application wrapper that contains all layout components
 export const AppWrapper = styled.div`
   display: grid;
   /* Explicit, valid grid‑template‑rows value: */
-  grid-template-rows: auto 1fr max-content minmax(clamp(13rem,20vh,15rem), auto);
+  grid-template-rows: auto 1fr max-content minmax(
+      clamp(13rem, 20vh, 15rem),
+      auto
+    );
 
   /* Use svh with dvh fallback for viewport height */
-  min-height: 100dvh; 
+  min-height: 100dvh;
+  max-height: 100dvh;
+  height: 100dvh;
   @supports (min-height: 100svh) {
     min-height: 100svh;
   }
-  width: 100%; 
+  width: 100%;
   /* Apply safe-area padding using CSS variables */
   padding-top: var(--safe-area-inset-top);
   padding-right: var(--safe-area-inset-right);
@@ -24,7 +29,7 @@ export const AppWrapper = styled.div`
 // Top banner area with padding-based height
 export const Banner = styled.div`
   padding: 0.75rem 1rem;
-  background-color: #CCC;
+  background-color: #ccc;
 `;
 
 // Flexible middle area that contains the crossword grid
@@ -33,11 +38,12 @@ export const CrosswordArea = styled.div`
   justify-content: center;
   align-items: center;
   overflow: hidden;
+  height: 100%;
 `;
 
 // Clue area with padding-based height
 export const ClueArea = styled.div`
-  background-color: ${props => props.theme.gridBackground || 'transparent'};
+  background-color: ${(props) => props.theme.gridBackground || "transparent"};
   display: flex;
   align-items: center;
   justify-content: center;
@@ -47,16 +53,17 @@ export const ClueArea = styled.div`
 // Keyboard area with padding-based height
 export const KeyboardArea = styled.div`
   padding: 0.75rem 0.1rem;
-  background-color: ${props => props.theme.keyboardBackground || props.theme.gridBackground || '#EEE'};
+  background-color: ${(props) =>
+    props.theme.keyboardBackground || props.theme.gridBackground || "#EEE"};
   overflow: hidden;
   display: flex;
   justify-content: center;
   align-items: center;
-  
+
   @media (max-width: 768px) {
     padding: 0.5rem 0.1rem;
   }
-  
+
   @media (max-width: 480px) {
     padding: 0.25rem 0;
   }
@@ -65,14 +72,14 @@ export const KeyboardArea = styled.div`
 // Temporary placeholder for keyboard - will be removed when actual keyboard is implemented
 export const KeyboardPlaceholder = styled.div`
   opacity: 0.5;
-  color: ${props => props.theme.textColor || '#666'};
+  color: ${(props) => props.theme.textColor || "#666"};
   font-size: 0.9rem;
   text-align: center;
 `;
 
 // Container for the timer and progress bar layout
 export const TimerBarContainer = styled.div<{ $visible?: boolean }>`
-  display: ${props => props.$visible ? 'flex' : 'none'};
+  display: ${(props) => (props.$visible ? "flex" : "none")};
   align-items: center;
   padding: 0.5rem 1rem;
   gap: 1rem;


### PR DESCRIPTION
Simplified the crossword grid rendering by removing the ref-based logic and relying solely on CSS for layout and sizing. This improves maintainability and reduces complexity in the component.

The brief was as follows: 

```
Problem: On mobile (e.g., iPhone 14 Pro Safari), vertical scrolling happens unintentionally due to the crossword SVG not shrinking vertically when screen height is limited.

Root Cause: The CrosswordWrapper scales based on width (aspect-ratio 1:1), but doesn’t shrink vertically when viewport height becomes restricted, pushing the app beyond 100svh.

Relevant Files:
    •    AppWrapper (grid, min-height 100svh)
    •    CrosswordArea (flex, center alignment)
    •    CrosswordWrapper (aspect-ratio: 1/1, containing SVG)

Solutions Tried: Adding height:100%, min-height:0, changing display from flex to grid/block, Set CrosswordWrapper to explicitly allow shrinking (flex-shrink:1) and constrain height (max-height:100%) within its flex parent. all unsuccessful 
```

There are two ways to solve this:

## Quick JS‑Driven Fix (Method 1)

	1.	Measured the wrapper (#svg-size-wrapper) via ResizeObserver.
	2.	Computed cellSize = min(wrapperWidth/cols, wrapperHeight/rows) so cells never exceeded either dimension.
	3.	Rewired SVG dimensions (viewBox, inline width/height) to use that dynamic cellSize.
	4.	Added min-height:0 and flex:1 1 auto on the flex containers so they could actually shrink.
> Result: The grid finally respected both width and height bounds—but required non‑trivial JS, state updates on every resize, > and introduced a feedback loop until the parent container’s height was made concrete.

The first method was the fastest, as the previous implementation already was using js to calculate cell and svg sizes, just not dynamically for the cells, I added a ref to the container which could calculate the cell size, as the min allowed, given height and width of container, this way if the width continues to resize but height doesn't, the cells don't overflow. 

However, in order to implement this solution, I added logs on dimension change, which is where I noticed the cells still resized beyond the allowed dimensions. The root of the runaway sizing is that the wrapper (`#svg-size-wrapper`) doesn’t have an actual height to clamp into — it only has max-height:100%, but its parent chain never establishes a concrete height, so the browser treats that percentage as `none`, and the SVG just grows to fill its own viewBox forever. Then the ResizeObserver measures that growing SVG and keeps ratcheting it up in a feedback loop. 

Setting size of the layout container to `100dvh`, instead of min/max-height, allowed the children to properly calculate sizes (can tell this because is dev tools, the height won't be greyed out, even if it has a calculated pixel value)  

## CSS‑Only Scaling (Method 2, Final)

```
<svg
  viewBox={`0 0 ${cols} ${rows}`}
  preserveAspectRatio="xMidYMid meet"
  style={{ width:"100%", height:"100%" }}
>

<g transform={`translate(${col}, ${row})`}>
  <rect x={0} y={0} width={1} height={1} … />
  {/* clue number & letter text using SVG‐relative coords/font sizes */}
</g>
```

Once this was fixed, there wasn't an explicit need for the refs, because the CSS grid now caps the height via `1fr` in a `100dvh` tall container, I simplified to:
	•	SVG’s viewBox defines a logical coordinate system: e.g. 0 0 cols rows.
	•	SVG width:100%; height:100%; preserveAspectRatio="xMidYMid meet".
	•	Remove JS‑calculated cellSize math—position each <Cell> at integer x=row, y=col in that space, and let the browser scale it to fit.

- `SvgWrapper` wraps the grid, as a flex‐item with `min-height: 0`: 
> **Why min-height:0?**
>By default flex‑items have min-height:auto, meaning “never smaller than my contents.” Setting it to 0 allows the wrapper to > actually shrink to the grid’s 1fr height, preventing overflow.
- `StyledSvg` simply enforces full‐container fill:
  - viewBox="0 0 cols rows" maps each crossword cell to a 1×1 unit.
  - preserveAspectRatio="xMidYMid meet" ensures uniform scaling inside the wrapper.
	-	Each <g> is placed via transform="translate(col, row)".
	-	Cells are <rect x=0 y=0 width=1 height=1 …/>.
	-	Clue numbers and letter‐guesses use relative SVG coordinates and font sizes (e.g. font-size="0.
 